### PR TITLE
Convert assert statements to warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Weakly-supervised High-resolution Segmentation of Mammography Images for Breast Cancer Diagnosis
 
+*This repository is a fork of the original implementation: [https://github.com/nyukat/GLAM](https://github.com/nyukat/GLAM).*
+
 ## Introduction
 This is an implementation of the GLAM (Global-Local Activation Maps) model as described in [our paper](https://openreview.net/pdf?id=nBT8eNF7aXr).  In this work, we introduce a novel neural network architecture to perform weakly-supervised segmentation of high-resolution images. The proposed model selects regions of interest via coarse-level localization, and then performs fine-grained segmentation of
 those regions.

--- a/src/modeling/glam.py
+++ b/src/modeling/glam.py
@@ -57,10 +57,10 @@ class MILSingleImageModel(nn.Module):
         top_k_prop_x = crops_x_small[:, :, 0] / h
         top_k_prop_y = crops_x_small[:, :, 1] / w
         # sanity check
-        assert np.max(top_k_prop_x) <= 1.0, "top_k_prop_x >= 1.0"
-        assert np.min(top_k_prop_x) >= 0.0, "top_k_prop_x <= 0.0"
-        assert np.max(top_k_prop_y) <= 1.0, "top_k_prop_y >= 1.0"
-        assert np.min(top_k_prop_y) >= 0.0, "top_k_prop_y <= 0.0"
+        # assert np.max(top_k_prop_x) <= 1.0, "top_k_prop_x >= 1.0"
+        # assert np.min(top_k_prop_x) >= 0.0, "top_k_prop_x <= 0.0"
+        # assert np.max(top_k_prop_y) <= 1.0, "top_k_prop_y >= 1.0"
+        # assert np.min(top_k_prop_y) >= 0.0, "top_k_prop_y <= 0.0"
         # interpolate the crop position from cam_size to x_original
         top_k_interpolate_x = np.expand_dims(np.around(top_k_prop_x * H), -1)
         top_k_interpolate_y = np.expand_dims(np.around(top_k_prop_y * W), -1)

--- a/src/modeling/glam.py
+++ b/src/modeling/glam.py
@@ -1,6 +1,7 @@
 """
 Module that contains networks for MIL family
 """
+import warnings
 import logging
 import numpy as np
 import torch
@@ -57,10 +58,14 @@ class MILSingleImageModel(nn.Module):
         top_k_prop_x = crops_x_small[:, :, 0] / h
         top_k_prop_y = crops_x_small[:, :, 1] / w
         # sanity check
-        # assert np.max(top_k_prop_x) <= 1.0, "top_k_prop_x >= 1.0"
-        # assert np.min(top_k_prop_x) >= 0.0, "top_k_prop_x <= 0.0"
-        # assert np.max(top_k_prop_y) <= 1.0, "top_k_prop_y >= 1.0"
-        # assert np.min(top_k_prop_y) >= 0.0, "top_k_prop_y <= 0.0"
+        if np.max(top_k_prop_x) <= 1.0:
+            warnings.warn("top_k_prop_x >= 1.0")
+        if np.min(top_k_prop_x) >= 0.0:
+            warnings.warn("top_k_prop_x <= 0.0")
+        if np.max(top_k_prop_y) <= 1.0:
+            warnings.warn("top_k_prop_y >= 1.0")
+        if np.min(top_k_prop_y) >= 0.0:
+            warnings.warn("top_k_prop_y <= 0.0")
         # interpolate the crop position from cam_size to x_original
         top_k_interpolate_x = np.expand_dims(np.around(top_k_prop_x * H), -1)
         top_k_interpolate_y = np.expand_dims(np.around(top_k_prop_y * W), -1)


### PR DESCRIPTION
Convert the assert statements to warnings. This prevents the model from crashing during the forward pass but still warns the user.